### PR TITLE
Actual bugfix for $.UIDeletable

### DIFF
--- a/src/chui/$-extensions.js
+++ b/src/chui/$-extensions.js
@@ -244,7 +244,7 @@
                });
                
                if ($.isiOS || $.isSafari) {
-                  $(list).on('swiperight singletap', 'li', function() {
+                  $(list).on('swiperight', 'li', function() {
                      $(this).removeClass('selected');
                   });
                }


### PR DESCRIPTION
As long as other parts of ChUI aren't binding to the "edit" and "done" buttons, this is a proper fix.

Sloppy contributing on my part before, this is a snippet from our tested codebase.
