### PR TITLE
Fix for selected segment button.

### DIFF
--- a/src/chui/collection-extensions.js
+++ b/src/chui/collection-extensions.js
@@ -84,6 +84,7 @@
             }  
          }
          this.on('singletap', '.button', function(e) {
+            e.stopPropagation();
             var $this = $(this);
             if (this.parentNode.classList.contains('paging')) return;
             $this.siblings('a').removeClass('selected');


### PR DESCRIPTION
The event listener on line 104 of load-init.js causes 'selected' to  be removed after 500ms. This prevents that.
