### PR TITLE
Can not use $.UIPaging within a $.UITabBar

### DIFF
--- a/src/chui/widget-factory.js
+++ b/src/chui/widget-factory.js
@@ -193,8 +193,10 @@
             $this.classList.add('selected');
             $(this).siblings('a').removeClass('selected');
             index = $(this).index();
-            $('.previous').removeClass('previous').addClass('next');
-            $('.current').removeClass('current').addClass('next');
+            $('article.previous').removeClass('previous').addClass('next');
+            $('nav.previous').removeClass('previous').addClass('next');
+            $('article.current').removeClass('current').addClass('next');
+            $('nav.current').removeClass('current').addClass('next');
             id = $('article').eq(index)[0].id;
             $.publish('chui/navigate/enter', id);
             if (window && window.jQuery) {


### PR DESCRIPTION
My app includes a tab bar which has an article which itself contains a paging set of screens. Unfortunately when switching tabs the UITabBar removes the "current" and "previous" classes of all DOM elements, irrespective if they're a part of the tab bar or not.

This fix only removes the "current" and "previous" from all "article" and "nav" elements, therefore leaving the "section" elements inside the $.UIPaging element intact.

I'm sure there might be better way of doing this, but this has worked perfectly well for me so far.
