### PR TITLE
Fix $.UIGoToArticle $.UINavigationHistory update

### DIFF
--- a/src/chui/navigation.js
+++ b/src/chui/navigation.js
@@ -137,7 +137,7 @@
       var currentToolbar;
       var destinationToolbar;
       $.publish('chui/navigate/leave', current[0].id);
-      $.UINavigationHistory.push(destinationID);
+      $.UINavigationHistory.push('#' + destinationID);
       $.publish('chui/navigate/enter', destination[0].id);
       current[0].scrollTop = 0;
       destination[0].scrollTop = 0;


### PR DESCRIPTION
UIGoToArticle wasn't setting the correct destination id in UINavigationHistory.  Added the '#' to stop the back button from breaking.
