### PR TITLE
projectpath for eg. & media & empty projectPath

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ var gulp = require('gulp')
 ,   footer = require('gulp-footer');
 
 //Add Trailing slash to projectPath if not exists.
-if pkg.projectPath != ""
+if (pkg.projectPath !== "")
   pkg.projectPath = pkg.projectPath.replace(/\/?$/, '/');
 
 // Define values for file headers:


### PR DESCRIPTION
adding projectPath as prefix to examples & media folders

adding trailing slash, if not present & projectpath is not empty.
