### PR TITLE
Fixed bug in split layout examples.

### DIFF
--- a/src/examples/splitlayout.html
+++ b/src/examples/splitlayout.html
@@ -37,7 +37,7 @@
         $('#detailTitle').text(this.textContent);
         var detail = $('.detail section');
         detail.empty();
-        detail.UIBusy({'color':'#000', 'size': '100px'});
+        detail.UIBusy({'color':'#000', 'size': '100'});
         var url = '../data/splitlayout/' + this.getAttribute('data-url') + '.html';
         // Delay 1/2 second to show busy indicator while loading.
         // Please do not do this for real world app!

--- a/src/rtl-examples/splitlayout.html
+++ b/src/rtl-examples/splitlayout.html
@@ -37,7 +37,7 @@
         $('#detailTitle').text(this.textContent);
         var detail = $('.detail section');
         detail.empty();
-        detail.UIBusy({'color':'#000', 'size': '100px'});
+        detail.UIBusy({'color':'#000', 'size': '100'});
         var url = '../data/splitlayout/' + this.getAttribute('data-url') + '.html';
         // Delay 1/2 second to show busy indicator while loading.
         // Please do not do this for real world app!


### PR DESCRIPTION
The busy indicator had a length identifier when it should have just be
an number for the size of the busy indicator.
