### PR TITLE
Fixed bug in carousel on Windows.

### DIFF
--- a/src/chui/carousel.js
+++ b/src/chui/carousel.js
@@ -22,6 +22,7 @@
       var transform = prefixStyle('transform');
       var transitionDuration = prefixStyle('transitionDuration');
       var hasTouch = 'ontouchstart' in window;
+      if (window.navigator.pointerEnabled || window.navigator.msPointerEnabled) hasTouch = false;
       var startEvent = $.eventStart;
       var moveEvent = $.eventMove;
       var endEvent = $.eventEnd;


### PR DESCRIPTION
Windows Phone 8.1 update added touchstart event support to IE11,
causing false positive for touch events on Windows Phone, introduced a
check for pointer events to reset the value for IE11 on mobile.
